### PR TITLE
Use csv module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,10 @@ share/python-wheels/
 *.egg
 MANIFEST
 
+# Files used to test Divisus
+*.txt
+*.csv
+
 # PyInstaller
 #  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.

--- a/divisus.py
+++ b/divisus.py
@@ -2,56 +2,40 @@
 # SPDX-License-Identifier: EPL-2.0
 
 import argparse
-import curses.ascii
+import csv
 import os.path
 import sys
 
 parser = argparse.ArgumentParser(description="Converts text files to CSV.", epilog="Licensed under the EPLv2 License.")
 parser.add_argument("-c", "--columns", default="3", type=int, choices=range(1,1000), metavar="[1-999]", help="how many lines to interpret as columns")
 parser.add_argument("-f", "--file-type", default="text", choices=["text"], help="The format of the input file")
-parser.add_argument("-v", "--version", action="version", version=os.path.basename(__file__)+" 0.1.0")
+parser.add_argument("-F" "--output-format", default="unix", choices=["excel", "unix"], help="The format of the output")
+parser.add_argument("-v", "--version", action="version", version=os.path.basename(__file__)+" 0.2.0")
 parser.add_argument("file", help="a valid input file")
 args = parser.parse_args()
 filepath = args.file
+out_format = args.F__output_format
 
+csv_dialect = ''
+col_num = args.columns
+if out_format == "excel":
+	csv_dialect = "excel"
+elif out_format == "unix":
+	csv_dialect = "unix"
+else:
+	pass
 try:
 	with open(filepath,mode="r") as stream:
-		csv_out = ""
-		current_col = 1
+		csv_out = csv.writer(sys.stdout, dialect=csv_dialect)
+		line_counter = 1
+		csv_row = []
 		for line in stream.read().splitlines():
-			new_line = ["\""]
-			nl_index = 1
-			for index in range(0,len(line)):
-				if curses.ascii.iscntrl(line[index]):
-					new_char = ""
-					# Since we are accessing a variable beyond
-					# the current index, it should be checked
-					# to ensure that it doesn't end up out of bounds.
-					if (len(line) - 1) == index:
-						pass
-					elif curses.ascii.iscntrl(line[index+1]):
-						pass
-					elif line[index+1].isalnum():
-						# Add a space to avoid having alphanumeric characters right
-						# beside punctuation when control characters are removed.
-						new_char = " "
-					else:
-						pass
-				elif line[index] == "\"":
-					new_char = "\'"
-				else:
-					new_char = line[index]
-				new_line.append(new_char)
-			new_line.append("\"")
-			if current_col == args.columns:
-				new_line.append("\n")
-				current_col = 1
-			else:
-				new_line.append(", ")
-				current_col = current_col + 1
-			for element in new_line:
-				csv_out = csv_out + element
-		print(csv_out, end="")
+			if line_counter == col_num:
+				csv_out.writerow(csv_row)
+				csv_row.clear()
+				line_counter = 1
+			csv_row += [line]
+			line_counter += 1
 except FileNotFoundError:
 	print("FE: File " + os.path.abspath(filepath) + " does not exist.", file=sys.stderr)
 	parser.print_usage()


### PR DESCRIPTION
By using the csv module, a lot of code was able to be removed, as well
as a dependency on curses. The unknown CSV format used before was the
unix dialect and support for it has been kept.

A few new dialects have
been added. To incorporate this change, a backwards compatible update to
the ABI has been provided.